### PR TITLE
Margin added around the text on launch page

### DIFF
--- a/src/molecules/launch-page/index.module.css
+++ b/src/molecules/launch-page/index.module.css
@@ -1,4 +1,4 @@
-.container{
+.container {
   background-color: var(--primarygreen);
   min-height: 100vh;
   min-width: 100vw;
@@ -12,7 +12,7 @@
 .container span {
   font-family: Mulish-bold;
   font-size: 36px;
-  font-weight: 700; 
+  font-weight: 700;
   color: var(--tertiarygreen);
+  margin: 0 1.5rem;
 }
-


### PR DESCRIPTION
Now the issue no #74  is now fixed. I have added a margin around the text
Intially the text look like this 
![image](https://github.com/SamagraX-Stencil/ui-templates/assets/82033937/b8ea7edf-c66a-4cb7-b718-86bbf31c7355)

but After adding margin the text look like this 
![image](https://github.com/SamagraX-Stencil/ui-templates/assets/82033937/82820d50-10d9-45f8-8553-0a70d9f3d226)

If any further changes required in issue #74 Please mention what changes needed further. I would happy to make changes. 