### PR TITLE
Added margin to avoid overlap.

### DIFF
--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -23,6 +23,7 @@ const Search = styled('div')(({ theme }) => ({
     backgroundColor: alpha(theme.palette.common.white, 0.25),
   },
   marginLeft: 0,
+  marginRight: 10,
   width: '100%',
   [theme.breakpoints.up('sm')]: {
     marginLeft: theme.spacing(1),


### PR DESCRIPTION

![profile_space](https://github.com/SamagraX-Stencil/ui-templates/assets/117532982/1e8c0e7a-fcdc-42a5-a3ab-7f31890799c2)

When a ThemePicker is to be selected, border is being overlapped with search bar.

![proresolved](https://github.com/SamagraX-Stencil/ui-templates/assets/117532982/1d515a76-c89e-45c9-a88d-057f2e544b67)

So added Right Margin to search.